### PR TITLE
fix(itables): fix header warning

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -365,7 +365,6 @@ def show_pr_table():
         ],
         classes="display compact",
         column_filters="header",
-        header=True,
         layout={"topEnd": None},
     )
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes the following warning:

```
/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/itables/typing.py:201: SyntaxWarning:

These arguments are not documented in ITableOptions: {'header'}. You can silence this warning by setting `itables.options.warn_on_undocumented_option=False`. If you believe ITableOptions should be updated, please make a PR or open an issue at https://github.com/mwouts/itables
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
